### PR TITLE
Add to cart for layers

### DIFF
--- a/src/common/addlayers/AddLayersDirective.js
+++ b/src/common/addlayers/AddLayersDirective.js
@@ -153,6 +153,10 @@
               scope.cart.push(layerConfig);
             };
 
+            scope.clearCart = function() {
+              scope.cart = [];
+            };
+
             scope.changeCredentials = function() {
               serverService.changeCredentials(scope.currentServer);
             };

--- a/src/common/addlayers/AddLayersDirective.js
+++ b/src/common/addlayers/AddLayersDirective.js
@@ -135,6 +135,7 @@
               scope.selectedLayer = {};
               $('#add-layer-dialog').modal('hide');
               scope.cart.forEach(addLayer);
+              scope.clearCart();
             };
 
             scope.previewLayer = function(layerConfig) {
@@ -150,7 +151,16 @@
             };
 
             scope.addToCart = function(layerConfig) {
-              scope.cart.push(layerConfig);
+              var configIndex = scope.cart.indexOf(layerConfig);
+              if (configIndex == -1) {
+                scope.cart.push(layerConfig);
+              } else {
+                scope.cart.splice(configIndex, 1);
+              }
+            };
+
+            scope.isInCart = function(layerConfig) {
+              return scope.cart.indexOf(layerConfig) !== -1 ? true : false;
             };
 
             scope.clearCart = function() {

--- a/src/common/addlayers/AddLayersDirective.js
+++ b/src/common/addlayers/AddLayersDirective.js
@@ -26,6 +26,7 @@
             ];
             scope.layerConfig = {Title: 'Title'};
             scope.selectedLayer = {};
+            scope.cart = [];
 
             var resetText = function() {
               scope.filterOptions.text = null;
@@ -109,13 +110,10 @@
 
             scope.selectRow = function(layerConfig) {
               scope.selectedLayer = layerConfig;
+              scope.addToCart(layerConfig);
             };
 
-            scope.addLayers = function(layerConfig) {
-              console.log(layerConfig);
-
-              scope.selectedLayer = {};
-              $('#add-layer-dialog').modal('hide');
+            var addLayer = function(layerConfig) {
               if (layerConfig.add) {
                 // NOTE: minimal config is the absolute bare minimum info that will be send to webapp containing
                 //       maploom such as geonode. At this point, only source (server id), and name are used. If you
@@ -132,6 +130,12 @@
                 mapService.zoomToExtentForProjection(layerConfig.extent, ol.proj.get(layerConfig.CRS));
               }
             };
+            scope.addLayers = function() {
+
+              scope.selectedLayer = {};
+              $('#add-layer-dialog').modal('hide');
+              scope.cart.forEach(addLayer);
+            };
 
             scope.previewLayer = function(layerConfig) {
               layerConfig.CRS = ['EPSG:4326'];
@@ -143,6 +147,10 @@
                 }),
                 layer
               ];
+            };
+
+            scope.addToCart = function(layerConfig) {
+              scope.cart.push(layerConfig);
             };
 
             scope.changeCredentials = function() {

--- a/src/common/addlayers/AddLayersDirective.spec.js
+++ b/src/common/addlayers/AddLayersDirective.spec.js
@@ -152,4 +152,11 @@ describe('StoryLegendDirective', function() {
       });
     });
   });
+  describe('#clearCart', function() {
+    it('clears the cart', function() {
+      compiledElement.scope().cart = [1];
+      compiledElement.scope().clearCart();
+      expect(compiledElement.scope().cart.length).toEqual(0);
+    });
+  });
 });

--- a/src/common/addlayers/AddLayersDirective.spec.js
+++ b/src/common/addlayers/AddLayersDirective.spec.js
@@ -128,7 +128,7 @@ describe('StoryLegendDirective', function() {
     });
     it('clears the cart', function() {
       compiledElement.scope().addLayers();
-      expect(compiledElement.scope().cart).toEqual(0);
+      expect(compiledElement.scope().cart.length).toEqual(0);
     });
   });
   describe('#addToCart', function() {

--- a/src/common/addlayers/AddLayersDirective.spec.js
+++ b/src/common/addlayers/AddLayersDirective.spec.js
@@ -108,12 +108,14 @@ describe('StoryLegendDirective', function() {
     var layerConfig;
     beforeEach(function() {
       layerConfig = { add: true, extent: [], CRS: 'EPSG:4326' };
+      compiledElement.scope().cart = [layerConfig];
+      scope.$digest();
     });
     it('adds the layer via mapSerice addLayer', function() {
       var spy = spyOn(mapService, 'addLayer');
       spyOn(mapService, 'zoomToExtentForProjection');
-      compiledElement.scope().addLayers(layerConfig);
-      expect(spy).toHaveBeenCalled();
+      compiledElement.scope().addLayers();
+      expect(spy).toHaveBeenCalledWith(layerConfig);
     });
     it('zooms to extent via mapService zoomToExtentForProjection', function() {
       spyOn(mapService, 'addLayer');
@@ -126,6 +128,27 @@ describe('StoryLegendDirective', function() {
       var spy = spyOn(mapService, 'zoomToExtentForProjection');
       compiledElement.scope().addLayers(layerConfig);
       expect(spy).toHaveBeenCalledWith([], ol.proj.get('EPSG:4326'));
+    });
+  });
+  describe('#addToCart', function() {
+    it('cart is empty by default', function() {
+      expect(compiledElement.scope().cart.length).toEqual(0);
+    });
+    it('add an item to the cart', function() {
+      var layerConfig = { add: true, extent: [], CRS: 'EPSG:4326' };
+      compiledElement.scope().addToCart(layerConfig);
+      expect(compiledElement.scope().cart.length).toEqual(1);
+    });
+    describe('with results', function() {
+      beforeEach(function() {
+        var layerConfig = { Title: 'Test', add: true, extent: [], CRS: 'EPSG:4326' };
+        spyOn(serverService, 'getLayersConfigByName').and.returnValue([layerConfig]);
+        scope.$digest();
+      });
+      it('click on a result adds it to cart', function() {
+        compiledElement.find('tr.result').click();
+        expect(compiledElement.scope().cart.length).toEqual(1);
+      });
     });
   });
 });

--- a/src/common/addlayers/AddLayersDirective.spec.js
+++ b/src/common/addlayers/AddLayersDirective.spec.js
@@ -105,17 +105,18 @@ describe('StoryLegendDirective', function() {
     });
   });
   describe('#addLayers', function() {
-    var layerConfig;
+    var layerConfig, minimalConfig;
     beforeEach(function() {
-      layerConfig = { add: true, extent: [], CRS: 'EPSG:4326' };
+      layerConfig = { add: true, Name: 'Test', extent: [], CRS: 'EPSG:4326' };
       compiledElement.scope().cart = [layerConfig];
       scope.$digest();
+      minimalConfig = { source: 0, name: layerConfig.Name };
     });
     it('adds the layer via mapSerice addLayer', function() {
       var spy = spyOn(mapService, 'addLayer');
       spyOn(mapService, 'zoomToExtentForProjection');
       compiledElement.scope().addLayers();
-      expect(spy).toHaveBeenCalledWith(layerConfig);
+      expect(spy).toHaveBeenCalledWith(minimalConfig);
     });
     it('zooms to extent via mapService zoomToExtentForProjection', function() {
       spyOn(mapService, 'addLayer');
@@ -142,7 +143,7 @@ describe('StoryLegendDirective', function() {
     describe('with results', function() {
       beforeEach(function() {
         var layerConfig = { Title: 'Test', add: true, extent: [], CRS: 'EPSG:4326' };
-        spyOn(serverService, 'getLayersConfigByName').and.returnValue([layerConfig]);
+        spyOn(serverService, 'getLayersConfigByName').andReturn([layerConfig]);
         scope.$digest();
       });
       it('click on a result adds it to cart', function() {

--- a/src/common/addlayers/partials/addlayers.tpl.html
+++ b/src/common/addlayers/partials/addlayers.tpl.html
@@ -52,7 +52,7 @@
                         <th>Title</th>
                         <th>Domain</th>
                       </tr>
-                      <tr class="result" ng-mouseover="previewLayer(layer);" ng-click="selectRow(layer)" ng-class="{'preview-hover': selectedLayer.Name === layer.Name}"
+                      <tr class="result" ng-mouseover="previewLayer(layer);" ng-click="selectRow(layer)" ng-class="{'preview-hover': isInCart(layer)}"
                         ng-repeat="layer in layersConfig = serverService.getLayersConfigByName('Local Geoserver') | filter:filterLayers | filter:filterAddedLayers">
                         <td>{{ layer.Title }}</td>
                         <td>{{ layer.domain }}</td>

--- a/src/common/addlayers/partials/addlayers.tpl.html
+++ b/src/common/addlayers/partials/addlayers.tpl.html
@@ -61,7 +61,7 @@
                   </div>
                 </div>
                 <div class="row actions" style="">
-                    <button type="button" class="btn btn-default btn-lg">CLEAR</button>
+                    <button type="button" ng-clik="clearCart();" class="btn btn-default btn-lg">CLEAR</button>
                     <button type="button" ng-click = "addLayers(selectedLayer)" ng-disabled="!selectedLayer.add" class="btn btn-default btn-lg">ADD</button>
                 </div>
 


### PR DESCRIPTION
## What does this PR do?

It adds layer to cart when you click on a layer. The `Add` button will add all layers in the cart to the map.
`Clear` will clear the cart.
## Realted Issue

[#18](https://github.com/boundlessgeo/exchange-search/issues/18)
### Still to do:
- [x] Show Items in Cart
