### PR TITLE
54 zoom data of the layer

### DIFF
--- a/src/common/layers/LayerInfoDirective.js
+++ b/src/common/layers/LayerInfoDirective.js
@@ -53,9 +53,12 @@
                 scope.repoName = repo.name;
                 scope.repoUUID = repo.uuid;
               }
-              var server = serverService.getServerById(scope.layer.get('metadata').serverId);
-              scope.serverName = server.name;
-              scope.serverURL = server.url;
+              if (goog.isDefAndNotNull(metadata.serverId)) {
+                var server = serverService.getServerById(metadata.serverId);
+                scope.serverName = server.name;
+                scope.serverURL = server.url;
+              }
+
               element.closest('.modal').modal('toggle');
             });
             function onResize() {

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -399,7 +399,7 @@
       var extent900913;
       if (goog.isDefAndNotNull(layer.getSource().getExtent)) {
         extent900913 = shrinkExtent(layer.getSource().getExtent(), 0);
-      } else {
+      } else if (goog.isDefAndNotNull(metadata.bbox)) {
         extent900913 = shrinkExtent(metadata.bbox.extent, 0);
       }
 
@@ -415,7 +415,6 @@
           }
         }
       }
-
       service_.zoomToExtent(extent900913);
     };
 
@@ -606,7 +605,11 @@
               abstract: fullConfig.Abstract,
               readOnly: false,
               editable: false,
-              projection: service_.getCRSCode(fullConfig.CRS)
+              projection: service_.getCRSCode(fullConfig.CRS),
+              bbox: {
+                extent: fullConfig.extent,
+                crs: fullConfig.CRS[0]
+              }
             },
             visible: true,
             source: new ol.source.XYZ({


### PR DESCRIPTION
## What does this PR do?
### Solving error when try to zoom to data and show the info of the layer.
- Add 'extent' and 'CRS' info to create full Layer when the type is 'mapproxy_tms'.
- Don't show info, if the layer has no server.
### Screenshot

**Zoom:**
![7ol0pak1q5](https://cloud.githubusercontent.com/assets/7197750/16601150/877d870a-42d0-11e6-8ab8-b0f45e7bf62e.gif)

**Info:**
<img width="700" alt="screen shot 2016-07-05 at 4 42 32 pm" src="https://cloud.githubusercontent.com/assets/7197750/16601158/99cc85be-42d0-11e6-97de-cda74842070b.png">
### Related Issue

[#54](https://github.com/boundlessgeo/exchange-search/issues/54)
