### PR TITLE
Calculate the number of items for the search results

### DIFF
--- a/src/common/addlayers/RegistryLayersDirective.js
+++ b/src/common/addlayers/RegistryLayersDirective.js
@@ -42,7 +42,8 @@
               var availableHeight = documentHeight() - otherHeights;
               return Math.round(availableHeight / itemHeight);
             };
-            scope.mapHeight = Math.round(documentHeight / 2);
+            var mapHeight = Math.round(documentHeight() / 2) + 'px';
+            scope.mapStyle = {height: mapHeight};
             scope.filterOptions.size = Math.max(calculateNumberofItems(), 5);
             scope.layerConfig = {Title: 'Title'};
             scope.selectedLayer = {};

--- a/src/common/addlayers/RegistryLayersDirective.js
+++ b/src/common/addlayers/RegistryLayersDirective.js
@@ -32,6 +32,16 @@
                 source: new ol.source.OSM()
               })
             ];
+            var documentHeight = function() {
+              var D = document;
+              return Math.max(D.body.scrollHeight, D.documentElement.scrollHeight, D.body.offsetHeight, D.documentElement.offsetHeight, D.body.clientHeight, D.documentElement.clientHeight);
+            };
+            var calculateNumberofItems = function() {
+              var itemHeight = 35;
+              var otherHeights = 377; //time search field, padding, table header, pagination
+              var availableHeight = documentHeight() - otherHeights;
+              return Math.round(availableHeight / itemHeight);
+            };
             scope.mapHeight = Math.round(documentHeight / 2);
             scope.filterOptions.size = Math.max(calculateNumberofItems(), 5);
             scope.layerConfig = {Title: 'Title'};

--- a/src/common/addlayers/RegistryLayersDirective.js
+++ b/src/common/addlayers/RegistryLayersDirective.js
@@ -19,7 +19,7 @@
               owner: null,
               text: null,
               docsPage: 1,
-              size: 10,
+              size: 5,
               minYear: null,
               maxYear: null,
               mapPreviewCoordinatesBbox: null,
@@ -33,6 +33,7 @@
               })
             ];
             scope.mapHeight = Math.round(documentHeight / 2);
+            scope.filterOptions.size = Math.max(calculateNumberofItems(), 5);
             scope.layerConfig = {Title: 'Title'};
             scope.selectedLayer = {};
             scope.cart = [];

--- a/src/common/addlayers/RegistryLayersDirective.js
+++ b/src/common/addlayers/RegistryLayersDirective.js
@@ -32,6 +32,7 @@
                 source: new ol.source.OSM()
               })
             ];
+            scope.mapHeight = Math.round(documentHeight / 2);
             scope.layerConfig = {Title: 'Title'};
             scope.selectedLayer = {};
             scope.cart = [];

--- a/src/common/addlayers/RegistryLayersDirective.spec.js
+++ b/src/common/addlayers/RegistryLayersDirective.spec.js
@@ -85,7 +85,7 @@ describe('registryLayersDirective', function() {
           text: null,
           owner: null,
           docsPage: 2,
-          size: 10
+          size: 5
         }));
       });
       it('next page if from is set', function() {
@@ -95,7 +95,7 @@ describe('registryLayersDirective', function() {
           text: null,
           owner: null,
           docsPage: 3,
-          size: 10
+          size: 5
         }));
       });
       it('calls search', function() {
@@ -132,7 +132,7 @@ describe('registryLayersDirective', function() {
           text: null,
           owner: null,
           docsPage: 1,
-          size: 10
+          size: 5
         }));
       });
       it('previous page if from is set', function() {
@@ -142,7 +142,7 @@ describe('registryLayersDirective', function() {
           text: null,
           owner: null,
           docsPage: 19,
-          size: 10
+          size: 5
         }));
       });
       it('previous is first page set to 1', function() {
@@ -152,7 +152,7 @@ describe('registryLayersDirective', function() {
           text: null,
           owner: null,
           docsPage: 1,
-          size: 10
+          size: 5
         }));
       });
       it('calls search', function() {

--- a/src/common/addlayers/partials/registryLayers.tpl.html
+++ b/src/common/addlayers/partials/registryLayers.tpl.html
@@ -39,7 +39,7 @@
                       Limit the search to data that includes features in the displayed area.
                   </div>
                   <div class="panel-body">
-                    <div class="loom-map" zoom="previewZoom" center="previewCenter" loom-map map-id="layer-map-preview" layers="previewLayers"></div>
+                    <div class="loom-map" style="mapStyle" zoom="previewZoom" center="previewCenter" loom-map map-id="layer-map-preview" layers="previewLayers"></div>
                   </div>
                 </div>
 

--- a/src/common/addlayers/style/addlayers.less
+++ b/src/common/addlayers/style/addlayers.less
@@ -302,12 +302,6 @@
   }
 }
 
-.loom-map{
-  div{
-    height: 324px;
-  }
-}
-
 .panel-cart {
 
   padding-left: 7px;

--- a/src/common/map/MapDirective.js
+++ b/src/common/map/MapDirective.js
@@ -5,11 +5,12 @@
   module.directive('loomMap',
       function($rootScope, serverService, mapService, geogigService, $translate, dialogService) {
         return {
-          template: '<div id="{{mapId}}"></div>',
+          template: '<div id="{{mapId}}" ng-style="style"></div>',
           scope: {
             mapId: '@',
             layers: '=',
             center: '=',
+            style: '=',
             zoom: '='
           },
           link: function(scope, element) {


### PR DESCRIPTION
## What does this PR do?

Calculate the number of elements to show in the page results based on the available real estate to show the results. The more space the more elements should be shown. But at least five elements should be shown at all times.

Calculate the height of the map dynamic as well. it will be the half of the available space.
### Screenshot

<img width="1278" alt="bildschirmfoto 2016-09-05 um 17 59 42" src="https://cloud.githubusercontent.com/assets/688980/18254561/2d2a0e5e-739f-11e6-98ac-08f7349f4dcd.png">
<img width="1262" alt="bildschirmfoto 2016-09-05 um 17 59 55" src="https://cloud.githubusercontent.com/assets/688980/18254562/2d58db62-739f-11e6-92d7-600ec3af6083.png">

<img width="2525" alt="bildschirmfoto 2016-09-06 um 12 31 25" src="https://cloud.githubusercontent.com/assets/688980/18270692/885e8752-742e-11e6-87f7-bae3b434edf4.png">
<img width="2531" alt="bildschirmfoto 2016-09-06 um 12 31 38" src="https://cloud.githubusercontent.com/assets/688980/18270693/888f4a2c-742e-11e6-9823-d0074ca9c64a.png">
