### PR TITLE
Minor style changes in info panel

### DIFF
--- a/src/common/addlayers/style/addlayers.less
+++ b/src/common/addlayers/style/addlayers.less
@@ -126,7 +126,7 @@
 }
 
 .registry-block {
-  height: 180px;
+  max-height: 180px;
   overflow-y: auto;
   font-size: 0.9em;
   font-weight: 300;


### PR DESCRIPTION
## What does this PR do?

Minor style changes in info panel, when there are not registry information.
### Screenshot

Before:
<img width="253" alt="screen shot 2016-09-06 at 18 48 40" src="https://cloud.githubusercontent.com/assets/7197750/18282698/9039c5b6-7462-11e6-84ab-7aaae4e0548c.png">

After:
<img width="249" alt="screen shot 2016-09-06 at 18 47 21" src="https://cloud.githubusercontent.com/assets/7197750/18282669/6db325b4-7462-11e6-990f-89e25c8e3633.png">
